### PR TITLE
Prepare to decomission demo.touchpoints.digital.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This site contains information and support materials for the Touchpoints product
 This Touchpoints product website is hosted at [touchpoints.digital.gov](https://touchpoints.digital.gov).
 It is a [Federalist](https://federalist.18f.gov/) site hosted on cloud.gov.
 
-Merges to `demo` are deployed to https://demo.touchpoints.digital.gov.
-
 Merges to `main` are deployed to https://touchpoints.digital.gov.
 
 ## Development


### PR DESCRIPTION
We're shutting down the demo site for touchpoints.digital.gov. The [preview capability](https://docs.cloud.gov/pages/using-pages/previews/) in Cloud.gov Pages is sufficient for viewing changes prior to deployment and we get billed for maintaining demo as a separate site.

This PR removes references to the demo site in our documentation.